### PR TITLE
changes to ExtractTextPlugin config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ const srcPath = path.join(__dirname, 'src');
 const modulesPath = path.join(__dirname, 'node_modules');
 
 const plugins = [
-  new ExtractTextPlugin('bundle.css', {
+  new ExtractTextPlugin({
+    filename: 'bundle.css',
     allChunks: true
   }),
   // new webpack.optimize.OccurrenceOrderPlugin(), (webpack@1)
@@ -94,7 +95,10 @@ module.exports = {
       loaders: ['babel']
     }, {
       test: /(\.scss|\.css)$/,
-      loader: ExtractTextPlugin.extract('style', 'css?sourceMap&modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss!sass?sourceMap')
+      loader: ExtractTextPlugin.extract({
+        fallbackLoader: 'style',
+        loader: 'css?sourceMap&modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss!sass?sourceMap'
+      })
     }, {
       test: /\.svg$/,
       include: srcPath,


### PR DESCRIPTION
Hi,

got these errors on first try to install.

```
npm start                                                                                                                                                 ⏎ master

> react-webpack-starter@0.2.0 start /Users/bsr/tmp/react-webpack-factory
> cross-env NODE_ENV=development node webpack.server.js

/Users/bsr/tmp/react-webpack-factory/node_modules/extract-text-webpack-plugin/index.js:171
        throw new Error("Breaking change: extract now only takes a single argument. Either an options " +
        ^

Error: Breaking change: extract now only takes a single argument. Either an options object *or* the loader(s).
Example: if your old code looked like this:
    ExtractTextPlugin.extract('style-loader', 'css-loader')

You would change it to:
    ExtractTextPlugin.extract({ fallbackLoader: 'style-loader', loader: 'css-loader' })

The available options are:
    loader: string | object | loader[]
    fallbackLoader: string | object | loader[]
    publicPath: string

    at Function.ExtractTextPlugin.extract (/Users/bsr/tmp/react-webpack-factory/node_modules/extract-text-webpack-plugin/index.js:171:9)

```
